### PR TITLE
Ability to exclude "inactive" items from suggestion

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -164,7 +164,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-material class="demo-paper" style="height: 300px; overflow: auto;">
         <p>An example of <code>&lt;paper-input-autocomplete-chips&gt;</code> with the filterInactive flag set to true:</p>
         <p>Won't suggest neither Alabama nor Alaska</p>
-        <paper-input-autocomplete-chips local-candidates="{{states}}" label="Chips" filter-inactive="true">
+        <paper-input-autocomplete-chips local-candidates="{{states}}" label="Chips" filter-inactive>
         </paper-input-autocomplete-chips>
 
       </paper-material>
@@ -268,13 +268,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               imgUrl: 'https://lh5.googleusercontent.com/-tlQ1LE9IdgI/AAAAAAAAAAI/AAAAAAAAAAA/xTWfNFP8w_M/s32-c-mo/photo.jpg',
               tag: 'read-only',
               readOnly: false,
-              active: false
+              inactive: true
             },
             {
               key: 2,
               text: "Alaska",
               imgUrl: 'http://lorempixel.com/256/256/',
-              active: false
+              inactive: true
             },
             {
               key: 3,

--- a/demo/index.html
+++ b/demo/index.html
@@ -159,6 +159,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <iron-icon icon="visibility" suffix></iron-icon>-->
         </paper-input-autocomplete-chips>
       </paper-material>
+
+
+      <paper-material class="demo-paper" style="height: 300px; overflow: auto;">
+        <p>An example of <code>&lt;paper-input-autocomplete-chips&gt;</code> with the filterInactive flag set to true:</p>
+        <p>Won't suggest neither Alabama nor Alaska</p>
+        <paper-input-autocomplete-chips local-candidates="{{states}}" label="Chips" filter-inactive="true">
+        </paper-input-autocomplete-chips>
+
+      </paper-material>
+
     
       <script>
         window.addEventListener('WebComponentsReady', function() {
@@ -257,12 +267,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               text: "Alabama",
               imgUrl: 'https://lh5.googleusercontent.com/-tlQ1LE9IdgI/AAAAAAAAAAI/AAAAAAAAAAA/xTWfNFP8w_M/s32-c-mo/photo.jpg',
               tag: 'read-only',
-              readOnly: false
+              readOnly: false,
+              active: false
             },
             {
               key: 2,
               text: "Alaska",
-              imgUrl: 'http://lorempixel.com/256/256/'
+              imgUrl: 'http://lorempixel.com/256/256/',
+              active: false
             },
             {
               key: 3,

--- a/demo/index.html
+++ b/demo/index.html
@@ -162,11 +162,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
       <paper-material class="demo-paper" style="height: 300px; overflow: auto;">
-        <p>An example of <code>&lt;paper-input-autocomplete-chips&gt;</code> with the filterInactive flag set to true:</p>
-        <p>Won't suggest neither Alabama nor Alaska</p>
-        <paper-input-autocomplete-chips local-candidates="{{states}}" label="Chips" filter-inactive>
+        <p>An example of <code>&lt;paper-input-autocomplete-chips&gt;</code> with the <code>noSuggestInactive</code> attribute:</p>
+        <p>It won't suggest neither Alabama nor Alaska</p>
+        <paper-input-autocomplete-chips local-candidates="{{states}}" label="Chips" no-suggest-inactive>
         </paper-input-autocomplete-chips>
-
       </paper-material>
 
     

--- a/input-autocomplete-behavior.html
+++ b/input-autocomplete-behavior.html
@@ -125,10 +125,10 @@
       },
 
       /**
-       * If set to true, candidate items which property 'active' are set to false
-       * won't be suggestedgit log
+       * If set to true, candidate items which property 'inactive' are set to true
+       * won't be suggested
        */
-      filterInactive: {
+      noSuggestInactive: {
         type: Boolean,
         value: false
       },
@@ -490,7 +490,7 @@
         if (candidates && candidates.length) {
           for (var i = 0; i < candidates.length; i ++) {
             var candidate = candidates[i];
-            if (Boolean(this.filterInactive) && !Boolean(candidate.inactive)) {
+            if (Boolean(this.noSuggestInactive) && !Boolean(candidate.inactive)) {
               if (patt.test(candidate.text.toLowerCase()) == true){
                 matched.push(candidate);
               }

--- a/input-autocomplete-behavior.html
+++ b/input-autocomplete-behavior.html
@@ -126,7 +126,7 @@
 
       /**
        * If set to true, candidate items which property 'active' are set to false
-       * won't be suggested
+       * won't be suggestedgit log
        */
       filterInactive: {
         type: Boolean,
@@ -473,19 +473,6 @@
       return 'dyn_' + this._strHashCode((text) ? text.toLowerCase() : '');
     },
 
-
-    _getCandidates: function() {
-        var candidates = this.localCandidates;
-
-        if (this.filterInactive) {
-          candidates = this.localCandidates.filter(function(obj){
-            return typeof(obj.active) === 'undefined' ? true : obj.active;
-          });
-        }
-
-        return candidates;
-    },
-
     _search: function(term){
       var that = this;
       this.xmlhttp;
@@ -498,12 +485,15 @@
 
         var patt =  new RegExp( this._scapeString( term.toLowerCase() ) );
         var matched = [];
-        var candidates = this._getCandidates();
+        var candidates = this.localCandidates;
 
-        if (candidates && candidates.length){
-          for (var i = 0; i < candidates.length; i ++){
-            if (patt.test(candidates[i].text.toLowerCase()) == true){
-              matched.push(candidates[i]);
+        if (candidates && candidates.length) {
+          for (var i = 0; i < candidates.length; i ++) {
+            var candidate = candidates[i];
+            if (Boolean(this.filterInactive) && !Boolean(candidate.inactive)) {
+              if (patt.test(candidate.text.toLowerCase()) == true){
+                matched.push(candidate);
+              }
             }
           }
         }

--- a/input-autocomplete-behavior.html
+++ b/input-autocomplete-behavior.html
@@ -123,6 +123,16 @@
         type: Boolean,
         value: false
       },
+
+      /**
+       * If set to true, candidate items which property 'active' are set to false
+       * won't be suggested
+       */
+      filterInactive: {
+        type: Boolean,
+        value: false
+      },
+
 	  },
 
     _tokenAcceptKeyCodesChanged: function (newValue) {
@@ -463,6 +473,19 @@
       return 'dyn_' + this._strHashCode((text) ? text.toLowerCase() : '');
     },
 
+
+    _getCandidates: function() {
+        var candidates = this.localCandidates;
+
+        if (this.filterInactive) {
+          candidates = this.localCandidates.filter(function(obj){
+            return typeof(obj.active) === 'undefined' ? true : obj.active;
+          });
+        }
+
+        return candidates;
+    },
+
     _search: function(term){
       var that = this;
       this.xmlhttp;
@@ -475,11 +498,12 @@
 
         var patt =  new RegExp( this._scapeString( term.toLowerCase() ) );
         var matched = [];
+        var candidates = this._getCandidates();
 
-        if ( this.localCandidates && this.localCandidates.length ){
-          for (var i = 0; i < this.localCandidates.length; i ++){
-            if (patt.test(this.localCandidates[i].text.toLowerCase()) == true){
-              matched.push(this.localCandidates[i]);
+        if (candidates && candidates.length){
+          for (var i = 0; i < candidates.length; i ++){
+            if (patt.test(candidates[i].text.toLowerCase()) == true){
+              matched.push(candidates[i]);
             }
           }
         }


### PR DESCRIPTION
Add new attribute filterInactive. If set to true, candidate items which property `active` are set to false will be excluded from suggestions

Attempt fo solve: WebPaperElements/paper-input-autocomplete-chips#24